### PR TITLE
feat: Add new data visualizations to Analytics page

### DIFF
--- a/src/Analytics.jsx
+++ b/src/Analytics.jsx
@@ -134,21 +134,26 @@ const Analytics = ({
           <DataVisualization data={filteredMovies} />
         </div>
 
-        {/* Placeholder for future analytics */}
+import YourVsImdbRatingsScatterPlot from './components/YourVsImdbRatingsScatterPlot.jsx';
+import MoviesRatedOverTime from './components/MoviesRatedOverTime.jsx';
+import AverageRatingPerGenre from './components/AverageRatingPerGenre.jsx';
+
+        {/* Movies Rated Over Time */}
         <div className="analytics-section">
-          <h2>Rating Trends Over Time</h2>
-          <div className="coming-soon">
-            <p>Rating trends analysis coming soon...</p>
-            <p>This will show how your movie ratings have changed over time.</p>
-          </div>
+          <h2>Movies Rated Per Month/Year</h2>
+          <MoviesRatedOverTime data={filteredMovies} />
         </div>
 
+        {/* Your Ratings vs. IMDB Ratings */}
         <div className="analytics-section">
-          <h2>Advanced Insights</h2>
-          <div className="coming-soon">
-            <p>Advanced insights coming soon...</p>
-            <p>Genre preferences, seasonal patterns, and more detailed analytics.</p>
-          </div>
+          <h2>Your Ratings vs. IMDB Ratings</h2>
+          <YourVsImdbRatingsScatterPlot data={filteredMovies} />
+        </div>
+
+        {/* Average Rating Per Genre */}
+        <div className="analytics-section">
+          <h2>Average Rating Per Genre</h2>
+          <AverageRatingPerGenre data={filteredMovies} />
         </div>
       </div>
     </div>

--- a/src/components/AverageRatingPerGenre.jsx
+++ b/src/components/AverageRatingPerGenre.jsx
@@ -1,0 +1,67 @@
+import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer, Label } from 'recharts';
+import PropTypes from 'prop-types';
+
+const AverageRatingPerGenre = ({ data }) => {
+  if (!data || data.length === 0) {
+    return <p>No data available for this visualization.</p>;
+  }
+
+  const genreRatings = data.reduce((acc, movie) => {
+    if (movie.genres && Array.isArray(movie.genres) && typeof movie.myRating === 'number') {
+      movie.genres.forEach(genre => {
+        if (!acc[genre]) {
+          acc[genre] = { totalRating: 0, count: 0 };
+        }
+        acc[genre].totalRating += movie.myRating;
+        acc[genre].count += 1;
+      });
+    }
+    return acc;
+  }, {});
+
+  const chartData = Object.entries(genreRatings)
+    .map(([genre, { totalRating, count }]) => ({
+      genre,
+      averageRating: count > 0 ? parseFloat((totalRating / count).toFixed(2)) : 0,
+    }))
+    .filter(item => item.count > 0) // Ensure we only show genres with rated movies
+    .sort((a, b) => b.averageRating - a.averageRating); // Sort by average rating descending
+
+  if (chartData.length === 0) {
+    return <p>No genre data with ratings found.</p>;
+  }
+
+  return (
+    <ResponsiveContainer width="100%" height={400}>
+      <BarChart
+        data={chartData}
+        margin={{
+          top: 5,
+          right: 30,
+          left: 20,
+          bottom: 25, // Increased for X-axis label
+        }}
+      >
+        <CartesianGrid strokeDasharray="3 3" />
+        <XAxis dataKey="genre">
+          <Label value="Genre" offset={-20} position="insideBottom" />
+        </XAxis>
+        <YAxis domain={[0, 10]}>
+          <Label value="Average Your Rating" angle={-90} position="insideLeft" style={{ textAnchor: 'middle' }} />
+        </YAxis>
+        <Tooltip />
+        <Legend verticalAlign="top" height={36}/>
+        <Bar dataKey="averageRating" name="Average Your Rating" fill="#8884d8" />
+      </BarChart>
+    </ResponsiveContainer>
+  );
+};
+
+AverageRatingPerGenre.propTypes = {
+  data: PropTypes.arrayOf(PropTypes.shape({
+    genres: PropTypes.arrayOf(PropTypes.string),
+    myRating: PropTypes.number,
+  })).isRequired,
+};
+
+export default AverageRatingPerGenre;

--- a/src/components/MoviesRatedOverTime.jsx
+++ b/src/components/MoviesRatedOverTime.jsx
@@ -1,0 +1,73 @@
+import { LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer, Label } from 'recharts';
+import PropTypes from 'prop-types';
+
+const MoviesRatedOverTime = ({ data }) => {
+  if (!data || data.length === 0) {
+    return <p>No data available for this visualization.</p>;
+  }
+
+  const countsByMonthYear = data.reduce((acc, movie) => {
+    if (movie.dataRated) {
+      const date = new Date(movie.dataRated);
+      // Ensure date is valid
+      if (!isNaN(date.getTime())) {
+        const year = date.getFullYear();
+        const month = date.getMonth() + 1; // getMonth() is 0-indexed
+        const monthYear = `${year}-${String(month).padStart(2, '0')}`;
+        acc[monthYear] = (acc[monthYear] || 0) + 1;
+      }
+    }
+    return acc;
+  }, {});
+
+  const chartData = Object.entries(countsByMonthYear)
+    .map(([monthYear, count]) => ({
+      monthYear,
+      count,
+    }))
+    .sort((a, b) => {
+      const [yearA, monthA] = a.monthYear.split('-').map(Number);
+      const [yearB, monthB] = b.monthYear.split('-').map(Number);
+      if (yearA !== yearB) {
+        return yearA - yearB;
+      }
+      return monthA - monthB;
+    });
+
+  if (chartData.length === 0) {
+    return <p>No movies with valid rating dates found.</p>;
+  }
+
+  return (
+    <ResponsiveContainer width="100%" height={400}>
+      <LineChart
+        data={chartData}
+        margin={{
+          top: 5,
+          right: 30,
+          left: 20,
+          bottom: 25, // Increased bottom margin for X-axis label
+        }}
+      >
+        <CartesianGrid strokeDasharray="3 3" />
+        <XAxis dataKey="monthYear">
+         <Label value="Month Rated" offset={-20} position="insideBottom" />
+        </XAxis>
+        <YAxis allowDecimals={false}>
+           <Label value="Number of Movies Rated" angle={-90} position="insideLeft" style={{ textAnchor: 'middle' }} />
+        </YAxis>
+        <Tooltip />
+        <Legend verticalAlign="top" height={36}/>
+        <Line type="monotone" dataKey="count" name="Movies Rated" stroke="#82ca9d" activeDot={{ r: 8 }} />
+      </LineChart>
+    </ResponsiveContainer>
+  );
+};
+
+MoviesRatedOverTime.propTypes = {
+  data: PropTypes.arrayOf(PropTypes.shape({
+    dataRated: PropTypes.string, // Assuming dataRated is a string like "YYYY-MM-DD"
+  })).isRequired,
+};
+
+export default MoviesRatedOverTime;

--- a/src/components/YourVsImdbRatingsScatterPlot.jsx
+++ b/src/components/YourVsImdbRatingsScatterPlot.jsx
@@ -1,0 +1,64 @@
+import { ScatterChart, Scatter, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, Label } from 'recharts';
+import PropTypes from 'prop-types';
+
+const YourVsImdbRatingsScatterPlot = ({ data }) => {
+  if (!data || data.length === 0) {
+    return <p>No data available for this visualization.</p>;
+  }
+
+  const chartData = data.map(movie => ({
+    x: movie.imdbRating,
+    y: movie.myRating,
+    title: movie.title,
+    year: movie.year,
+  }));
+
+  return (
+    <ResponsiveContainer width="100%" height={400}>
+      <ScatterChart
+        margin={{
+          top: 20,
+          right: 20,
+          bottom: 40, // Increased bottom margin for X-axis label
+          left: 20,
+        }}
+      >
+        <CartesianGrid />
+        <XAxis type="number" dataKey="x" name="IMDB Rating" unit="" domain={[0, 10]}>
+          <Label value="IMDB Rating" offset={-25} position="insideBottom" />
+        </XAxis>
+        <YAxis type="number" dataKey="y" name="Your Rating" unit="" domain={[0, 10]}>
+          <Label value="Your Rating" angle={-90} position="insideLeft" style={{ textAnchor: 'middle' }} />
+        </YAxis>
+        <Tooltip
+          cursor={{ strokeDasharray: '3 3' }}
+          content={({ active, payload }) => {
+            if (active && payload && payload.length) {
+              const point = payload[0].payload;
+              return (
+                <div className="custom-tooltip" style={{ backgroundColor: 'rgba(255, 255, 255, 0.9)', padding: '10px', border: '1px solid #ccc', borderRadius: '4px' }}>
+                  <p style={{ color: '#333', fontWeight: 'bold' }}>{`${point.title} (${point.year})`}</p>
+                  <p style={{ color: '#666' }}>{`IMDB: ${point.x}`}</p>
+                  <p style={{ color: '#666' }}>{`You: ${point.y}`}</p>
+                </div>
+              );
+            }
+            return null;
+          }}
+        />
+        <Scatter name="Movies" data={chartData} fill="#8884d8" />
+      </ScatterChart>
+    </ResponsiveContainer>
+  );
+};
+
+YourVsImdbRatingsScatterPlot.propTypes = {
+  data: PropTypes.arrayOf(PropTypes.shape({
+    imdbRating: PropTypes.number,
+    myRating: PropTypes.number,
+    title: PropTypes.string,
+    year: PropTypes.number,
+  })).isRequired,
+};
+
+export default YourVsImdbRatingsScatterPlot;


### PR DESCRIPTION
Implemented three new charts on the Analytics page using Recharts:

1.  **Your Ratings vs. IMDB Ratings Scatter Plot:** Visualizes the correlation between user ratings and IMDB ratings for filtered movies.
2.  **Movies Rated Per Month/Year Line Chart:** Shows the trend of how many movies were rated over time.
3.  **Average Rating per Genre Bar Chart:** Displays the user's average rating for each movie genre.

These charts are integrated into the existing filter system and update dynamically based on the selected filters. Added appropriate labels and tooltips for better usability.